### PR TITLE
fix: missing extra deps for pyvista

### DIFF
--- a/requirements/requirements_examples.txt
+++ b/requirements/requirements_examples.txt
@@ -2,5 +2,5 @@ ansys-workbench-core==0.3.dev0
 ansys-fluent-core==0.20.1
 ansys-fluent-visualization==0.9.0
 ansys-mechanical-core==0.10.11
-pyvista
+pyvista[jupyter]
 matplotlib==3.9.0


### PR DESCRIPTION
Includes the `pyvista[jupyter]` extras for rendering scenes in Jupyter notebooks.