### PR TITLE
feat/updated examples with server work dir arg

### DIFF
--- a/examples/axisymmetric-rotor/main.py
+++ b/examples/axisymmetric-rotor/main.py
@@ -15,17 +15,14 @@ from ansys.mechanical.core import launch_mechanical
 
 workdir = pathlib.Path("__file__").parent
 
-server_workdir = workdir / 'server_workdir'  
-server_workdir.mkdir(exist_ok=True)
-
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 agdb = workdir / "agdb"
 
-wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
+wb = launch_workbench(client_workdir=str(workdir.absolute()))
 
-# Upload the project files to the server using the `upload_file` method.
-# The files uploaded are `axisymmetric_model.agdb`, `rotor_3d_model.agdb`.
+# Upload the project files to the server using the `upload_file_from_example_repo` method. 
+# The files uploaded are `axisymmetric_model.agdb`, `rotor_3d_model.agdb`. 
 
 wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/axisymmetric_model.agdb")
 wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/rotor_3d_model.agdb")
@@ -247,3 +244,5 @@ for file in glob.glob(source_dir + '/*'):
 
 mechanical.exit()
 wb.exit()
+
+

--- a/examples/axisymmetric-rotor/main.py
+++ b/examples/axisymmetric-rotor/main.py
@@ -17,7 +17,6 @@ workdir = pathlib.Path("__file__").parent
 
 assets = workdir / "assets"
 scripts = workdir / "scripts"
-agdb = workdir / "agdb"
 
 wb = launch_workbench(client_workdir=str(workdir.absolute()))
 

--- a/examples/axisymmetric-rotor/main.py
+++ b/examples/axisymmetric-rotor/main.py
@@ -14,17 +14,23 @@ from ansys.mechanical.core import launch_mechanical
 # The `launch_workbench` function starts a Workbench session with the specified directory.
 
 workdir = pathlib.Path("__file__").parent
+
+server_workdir = workdir / 'server_workdir'  
+server_workdir.mkdir(exist_ok=True)
+
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 agdb = workdir / "agdb"
 
-wb = launch_workbench(client_workdir=str(workdir.absolute()))
+wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
 
 # Upload the project files to the server using the `upload_file` method.
 # The files uploaded are `axisymmetric_model.agdb`, `rotor_3d_model.agdb`.
 
-wb.upload_file(str(agdb / "axisymmetric_model.agdb"))
-wb.upload_file(str(agdb / "rotor_3d_model.agdb"))
+wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/axisymmetric_model.agdb")
+wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/rotor_3d_model.agdb")
+wb.upload_file(str(scripts / "axisymmetric_rotor.py"))
+wb.upload_file(str(scripts / "rotor_3d.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry.
 # The log file is set to `wb_log_file.log` and the name of the system created is stored in `sys_name` and printed.

--- a/examples/axisymmetric-rotor/main.py
+++ b/examples/axisymmetric-rotor/main.py
@@ -25,8 +25,6 @@ wb = launch_workbench(client_workdir=str(workdir.absolute()))
 
 wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/axisymmetric_model.agdb")
 wb.upload_file_from_example_repo("axisymmetric-rotor/agdb/rotor_3d_model.agdb")
-wb.upload_file(str(scripts / "axisymmetric_rotor.py"))
-wb.upload_file(str(scripts / "rotor_3d.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry.
 # The log file is set to `wb_log_file.log` and the name of the system created is stored in `sys_name` and printed.
@@ -243,5 +241,3 @@ for file in glob.glob(source_dir + '/*'):
 
 mechanical.exit()
 wb.exit()
-
-

--- a/examples/cooled-turbine-blade/main.py
+++ b/examples/cooled-turbine-blade/main.py
@@ -20,16 +20,13 @@ from ansys.mechanical.core import launch_mechanical
 
 workdir = pathlib.Path("__file__").parent
 
-server_workdir = workdir / 'server_workdir'  
-server_workdir.mkdir(exist_ok=True)
-
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 wbpz = workdir / "wbpz"
 
-wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
+wb = launch_workbench(client_workdir=str(workdir.absolute()))
 
-# Upload project files to the server using the `upload_file` method. 
+# Upload the project files to the server using the `upload_file_from_example_repo` method. 
 # The file to upload is `cooled_turbine_blade.wbpz`.
 
 

--- a/examples/cooled-turbine-blade/main.py
+++ b/examples/cooled-turbine-blade/main.py
@@ -19,16 +19,22 @@ from ansys.mechanical.core import launch_mechanical
 # The `launch_workbench` function is called to start a Workbench session with specified directory.
 
 workdir = pathlib.Path("__file__").parent
+
+server_workdir = workdir / 'server_workdir'  
+server_workdir.mkdir(exist_ok=True)
+
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 wbpz = workdir / "wbpz"
 
-wb = launch_workbench(client_workdir=str(workdir.absolute()))
+wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
 
 # Upload project files to the server using the `upload_file` method. 
 # The file to upload is `cooled_turbine_blade.wbpz`.
 
-wb.upload_file(str(wbpz / "cooled_turbine_blade.wbpz"))
+
+wb.upload_file_from_example_repo("cooled-turbine-blade/wbpz/cooled_turbine_blade.wbpz")
+wb.upload_file(str(scripts / "cooled_turbine_blade.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry using the `run_script_file` method. 
 # The `set_log_file` method is used to direct the logs to `wb_log_file.log`. 

--- a/examples/cooled-turbine-blade/main.py
+++ b/examples/cooled-turbine-blade/main.py
@@ -30,7 +30,6 @@ wb = launch_workbench(client_workdir=str(workdir.absolute()))
 
 
 wb.upload_file_from_example_repo("cooled-turbine-blade/wbpz/cooled_turbine_blade.wbpz")
-wb.upload_file(str(scripts / "cooled_turbine_blade.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry using the `run_script_file` method. 
 # The `set_log_file` method is used to direct the logs to `wb_log_file.log`. 

--- a/examples/cooled-turbine-blade/main.py
+++ b/examples/cooled-turbine-blade/main.py
@@ -22,7 +22,6 @@ workdir = pathlib.Path("__file__").parent
 
 assets = workdir / "assets"
 scripts = workdir / "scripts"
-wbpz = workdir / "wbpz"
 
 wb = launch_workbench(client_workdir=str(workdir.absolute()))
 

--- a/examples/cyclic-symmetry-analysis/main.py
+++ b/examples/cyclic-symmetry-analysis/main.py
@@ -16,16 +16,21 @@ from ansys.mechanical.core import launch_mechanical
 # The `launch_workbench` function is called to start a Workbench session with specified directory.
 
 workdir = pathlib.Path("__file__").parent
+
+server_workdir = workdir / 'server_workdir'  
+server_workdir.mkdir(exist_ok=True)
+
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 cdb = workdir / "cdb"
 
-wb = launch_workbench(client_workdir=str(workdir.absolute()))
+wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
 
 # Upload project files to the server using the `upload_file` method. 
 # The file to upload is `sector_model.cdb`.
 
-wb.upload_file(str(cdb / "sector_model.cdb"))
+wb.upload_file_from_example_repo("cyclic-symmetry-analysis/cdb/sector_model.cdb")
+wb.upload_file(str(scripts / "cyclic_symmetry_analysis.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry using the `run_script_file` method. 
 # The `set_log_file` method is used to direct the logs to `wb_log_file.log`. 

--- a/examples/cyclic-symmetry-analysis/main.py
+++ b/examples/cyclic-symmetry-analysis/main.py
@@ -17,16 +17,13 @@ from ansys.mechanical.core import launch_mechanical
 
 workdir = pathlib.Path("__file__").parent
 
-server_workdir = workdir / 'server_workdir'  
-server_workdir.mkdir(exist_ok=True)
-
 assets = workdir / "assets"
 scripts = workdir / "scripts"
 cdb = workdir / "cdb"
 
-wb = launch_workbench(release="242", server_workdir=str(server_workdir.absolute()), client_workdir=str(workdir.absolute()))
+wb = launch_workbench(client_workdir=str(workdir.absolute()))
 
-# Upload project files to the server using the `upload_file` method. 
+# Upload the project files to the server using the `upload_file_from_example_repo` method. 
 # The file to upload is `sector_model.cdb`.
 
 wb.upload_file_from_example_repo("cyclic-symmetry-analysis/cdb/sector_model.cdb")

--- a/examples/cyclic-symmetry-analysis/main.py
+++ b/examples/cyclic-symmetry-analysis/main.py
@@ -19,7 +19,6 @@ workdir = pathlib.Path("__file__").parent
 
 assets = workdir / "assets"
 scripts = workdir / "scripts"
-cdb = workdir / "cdb"
 
 wb = launch_workbench(client_workdir=str(workdir.absolute()))
 

--- a/examples/cyclic-symmetry-analysis/main.py
+++ b/examples/cyclic-symmetry-analysis/main.py
@@ -26,7 +26,6 @@ wb = launch_workbench(client_workdir=str(workdir.absolute()))
 # The file to upload is `sector_model.cdb`.
 
 wb.upload_file_from_example_repo("cyclic-symmetry-analysis/cdb/sector_model.cdb")
-wb.upload_file(str(scripts / "cyclic_symmetry_analysis.py"))
 
 # Execute a Workbench script (`project.wbjn`) to define the project and load the geometry using the `run_script_file` method. 
 # The `set_log_file` method is used to direct the logs to `wb_log_file.log`. 


### PR DESCRIPTION
@franknli Could you please review these changes and approve it accordingly. Thanks!

These examples have following changes:

1. Specified "release" and "server_workdir" arguments to showcase to the user (though these options are default)
2. Specified "upload_file_from_example_repo" API to download and upload input files from example repo to server working directory. With the usage of this API, we can track the issues if it's occurring with the future code changes. 