### PR TITLE
fix: aedt example

### DIFF
--- a/doc/source/basic-examples.rst
+++ b/doc/source/basic-examples.rst
@@ -8,3 +8,4 @@ library.
 
    examples/logging/main
    examples/ansys-fluent-workflow/main
+   examples/ansys-aedt-workflow/main


### PR DESCRIPTION
Adding aedt example path for nbsphinx