### PR TITLE
Bumped down mechanical core version

### DIFF
--- a/requirements/requirements_examples.txt
+++ b/requirements/requirements_examples.txt
@@ -1,7 +1,7 @@
 ansys-workbench-core==0.10.0
-ansys-fluent-core==0.38.0
-ansys-fluent-visualization==0.24.0
+ansys-fluent-core==0.38.dev2
+ansys-fluent-visualization==0.24.dev0
 pyaedt == 0.20.1
-ansys-mechanical-core==0.11.38
+ansys-mechanical-core==0.11.34
 pyvista[jupyter]
 matplotlib==3.10.6

--- a/requirements/requirements_examples.txt
+++ b/requirements/requirements_examples.txt
@@ -1,6 +1,6 @@
 ansys-workbench-core==0.10.0
-ansys-fluent-core==0.38.dev2
-ansys-fluent-visualization==0.24.dev0
+ansys-fluent-core==0.37.0
+ansys-fluent-visualization==0.24.0
 pyaedt == 0.20.1
 ansys-mechanical-core==0.11.34
 pyvista[jupyter]


### PR DESCRIPTION
Changed ansys-mechanical-core dependency from 0.11.38 to 0.11.34 due to this version bringing a conflicting dependency. Also changed ansys-fluent-* to dev* versions since the non dev versions do not exist.